### PR TITLE
Create more understandable OPENWHISK_HOME missing msg

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,11 @@
 def owPath = System.getenv("OPENWHISK_HOME") ?: '../open'
 def owDirectory = new File(owPath)
 
+if (!owDirectory.exists()) {
+    throw new GradleScriptException("Environment variable OPENWHISK_HOME must point to a valid OpenWhisk build", null)
+}
+
+
 include 'common:scala'; project(':common:scala').projectDir = new File(owDirectory, 'common/scala')
 include 'core:controller'; project(':core:controller').projectDir = new File(owDirectory, 'core/controller')
 include 'core:invoker'; project(':core:invoker').projectDir = new File(owDirectory, 'core/invoker')


### PR DESCRIPTION
Attempting build with OPENWHISK_HOME unset (and openwhisk not in a specific default) caused an unhelpful error message:

```
FAILURE: Build failed with an exception.

* Where:
Build file '/home/jonpspri/Projects/openwhisk-runtime-nodejs/tests/build.gradle' line: 23

* What went wrong:
A problem occurred evaluating project ':tests'.
> Could not get unknown property 'sourceSets' for project ':whisktests' of type org.gradle.api.Project.
```

Changes instead produce an error message that identifies the problem and correct it:

```
FAILURE: Build failed with an exception.

* Where:
Settings file '/Users/jpspring/Projects/incubator-openwhisk-runtime-nodejs/settings.gradle' line: 5

* What went wrong:
Environment variable OPENWHISK_HOME must point to a valid OpenWhisk build
```