### PR TITLE
Enable Class Data Sharing option for Java runtime

### DIFF
--- a/core/javaAction/Dockerfile
+++ b/core/javaAction/Dockerfile
@@ -35,4 +35,6 @@ RUN cd /javaAction; ./gradlew oneJar
 
 RUN rm -rf /javaAction/src
 
-CMD ["java", "-jar", "/javaAction/build/libs/javaAction-all.jar"]
+RUN java -Xshare:dump
+
+CMD ["java", "-Xshare:on", "-jar", "/javaAction/build/libs/javaAction-all.jar"]


### PR DESCRIPTION
It enables class data sharing feature of the java runtime to improve the performance of the JVM(startup) and memory footprint.

Issue #7 

Signed-off-by: Parameswaran Selvam <sparameswara@gmail.com>