### PR TITLE
Bump up Eclipse OpenJ9 to the latest release jdk8u181-b13_openj9-0.9.0

### DIFF
--- a/core/java8/CHANGELOG.md
+++ b/core/java8/CHANGELOG.md
@@ -19,6 +19,9 @@
 
 # Java 8 OpenWhisk Runtime Container
 
+## 1.1.3
+Changes:
+- Bump up Eclipse OpenJ9 to the latest release [jdk8u181-b13_openj9-0.9.0](https://hub.docker.com/r/adoptopenjdk/openjdk8-openj9/tags/) [#69](https://github.com/apache/incubator-openwhisk-runtime-java/pull/69)
 
 ## 1.1.2
 Changes:

--- a/core/java8/Dockerfile
+++ b/core/java8/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-FROM adoptopenjdk/openjdk8-openj9:jdk8u162-b12_openj9-0.8.0
+FROM adoptopenjdk/openjdk8-openj9:jdk8u181-b13_openj9-0.9.0
 
 RUN rm -rf /var/lib/apt/lists/* && apt-get clean && apt-get update \
 	&& apt-get install -y --no-install-recommends locales \


### PR DESCRIPTION
openj9-0.9.0 has container awareness and has better default memory settings wrt to containers. Please see this [blog](https://blog.openj9.org/2018/06/12/eclipse-openj9-in-containers/) for more details.