### PR TITLE
Kind: java:8 -> java

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ This works on any deployment of Apache OpenWhisk
 
 To use on a deployment of OpenWhisk that contains the runtime as a kind:
 ```
-wsk action update helloJava hello.jar --main Hello --kind java:8
+wsk action update helloJava hello.jar --main Hello --kind java
 ```
 
 ### Invoke the Java Action


### PR DESCRIPTION
I think in recent openwhisk it is just `java` - I got `kind 'java:8' not in Set(dotnet:2.2, go:1.11, nodejs:10, ballerina:0.990, ruby:2.5, nodejs:8, blackbox, java, swift:4.2, sequence, nodejs:6, python:3, python:2, php:7.3)` for `java:8`