### PR TITLE
Update Base image to fix vulnerabilities

### DIFF
--- a/core/java8/CHANGELOG.md
+++ b/core/java8/CHANGELOG.md
@@ -19,6 +19,9 @@
 
 # Java 8 OpenWhisk Runtime Container
 
+# next Release
+- use `ibm-semeru-runtimes:open-8u392-b08-jdk-focal` as baseimage
+
 # 1.19.0
  - use `ibm-semeru-runtimes:open-8u382-b05-jdk-focal` as baseimage
 

--- a/core/java8/Dockerfile
+++ b/core/java8/Dockerfile
@@ -16,7 +16,7 @@
 #
 
 # Use AdoptOpenJDK's JDK8, OpenJ9, ubuntu
-FROM ibm-semeru-runtimes:open-8u382-b05-jdk-focal
+FROM ibm-semeru-runtimes:open-8u392-b08-jdk-focal
 
 RUN rm -rf /var/lib/apt/lists/* \
     && apt-get clean \

--- a/core/java8actionloop/CHANGELOG.md
+++ b/core/java8actionloop/CHANGELOG.md
@@ -19,6 +19,9 @@
 
 # Java 8 OpenWhisk Runtime Container
 
+# next Release
+- use `ibm-semeru-runtimes:open-8u392-b08-jdk-focal` as baseimage
+
 # 1.19.0
  - use `ibm-semeru-runtimes:open-8u382-b05-jdk-focal` as baseimage
  - update go proxy 1.21@1.23.0 (#157)

--- a/core/java8actionloop/Dockerfile
+++ b/core/java8actionloop/Dockerfile
@@ -34,7 +34,7 @@ RUN curl -sL \
   && GO111MODULE=on CGO_ENABLED=0 go build -o /bin/proxy
 
 # Use AdoptOpenJDK's JDK8, OpenJ9, ubuntu
-FROM ibm-semeru-runtimes:open-8u382-b05-jdk-focal
+FROM ibm-semeru-runtimes:open-8u392-b08-jdk-focal
 
 # select the builder to use
 ARG GO_PROXY_BUILD_FROM=release


### PR DESCRIPTION
Use ibm-semeru-runtimes:open-8u392-b08-jdk-focal as baseimage to fix vulnerabilities